### PR TITLE
docs: clarify typofixer-en spelling variants

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,7 @@
 ## Status (per last release)
 
 * [![https://hub.espanso.org/typofixer-en](https://img.shields.io/badge/typofixer-%F0%9F%87%AC%F0%9F%87%A7%20%F0%9F%87%BA%F0%9F%87%B8-white.svg)]([https://hub.espanso.org/typofixer-en]): *<!--en-words-->17630<!--en-words-end-->* words with *<!--en-typos-->67297<!--en-typos-end-->* typos
+  * `typofixer-en` aggregates English typo-correction rules from multiple sources, so it may include both US and UK spelling variants.
 * [![https://hub.espanso.org/typofixer-fr](https://img.shields.io/badge/typofixer-%F0%9F%87%AB%F0%9F%87%B7%20-white.svg)](https://hub.espanso.org/typofixer-fr): *<!--fr-words-->69<!--fr-words-end-->* words with *<!--fr-typos-->70<!--fr-typos-end-->* typos
 * [![https://hub.espanso.org/typofixer-it](https://img.shields.io/badge/typofixer-%F0%9F%87%AE%F0%9F%87%B9%20-white.svg)](https://hub.espanso.org/typofixer-it): *<!--it-words-->2134<!--it-words-end-->* words with *<!--it-typos-->2994<!--it-typos-end-->* typos
 * [![https://hub.espanso.org/typofixer-es](https://img.shields.io/badge/typofixer-%F0%9F%87%AA%F0%9F%87%B8%20-white.svg)](https://hub.espanso.org/typofixer-es): *<!--es-words-->103<!--es-words-end-->* words with *<!--es-typos-->118<!--es-typos-end-->* typos


### PR DESCRIPTION
## Summary
- add a README note that `typofixer-en` aggregates English typo-correction rules from multiple sources
- clarify that the package may include both US and UK spelling variants

## Validation
- `rg -n 'typofixer-en|English typo-correction|US and UK|spelling variants|behaviour|behavior|colourless|colorless|flavour|flavor' readme.md typofixer-en/package.yml words/en.json`
- `git diff --check`

Addresses #9.